### PR TITLE
minor info update

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = imgur
 
-Description goes here.
+The imgur gem provides a Ruby interface to the Imgur API.
 
 == Note on Patches/Pull Requests
  

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ begin
     gem.email = "jdp34@njit.edu"
     gem.homepage = "http://github.com/jdp/imgur"
     gem.authors = ["Justin Poliey"]
+    gem.licenses = ["MIT"]
     gem.add_development_dependency "bacon", ">= 1.1.0"
     gem.add_development_dependency "yard", ">= 0.2.3.5"
     gem.add_development_dependency "curb", ">= 0.5.4.0"


### PR DESCRIPTION
This PR adds license metadata to the Jeweler/Gemspec config in the Rakefile and a very brief description to the README to replace "Description goes here."  Tests do not seem practical for these changes (especially the README edit).